### PR TITLE
Do not fail upgrade path test if there is no version available to upgrade from

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It tests clean installation and upgrade for integration packages in CentOS, Suse
 Usage and defaults:
 ```yaml
     - name: Test packages installation
-      uses: paologallinaharbur/test-packages-action/linux@v1
+      uses: newrelic/integrations-pkg-test-action/linux@v1
       with:
         tag: ${{ env.TAG }} # Required, trailing v is stripped automatically if found
         integration: 'nri-${{ env.INTEGRATION }}' # Required, with nri- prefix
@@ -37,7 +37,7 @@ The following inputs can be specified to override the default behavior
 Usage and defaults:
 ```yaml
     - name: Test packages installation
-      uses: paologallinaharbur/test-packages-action/windows@v1
+      uses: newrelic/integrations-pkg-test-action/windows@v1
       with:
         tag: ${{ env.TAG }} # Required, trailing v is stripped automatically if found
         integration: 'nri-${{ env.INTEGRATION }}' # Required, with nri- prefix

--- a/linux/action.yml
+++ b/linux/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: true
     default: 'nri-test'
   upgrade:
-    description: 'Wether to test upgrade path as well'
+    description: 'Whether to test upgrade path as well'
     required: false
     default: "true"
   postInstall:

--- a/linux/centos.dockerfile
+++ b/linux/centos.dockerfile
@@ -20,5 +20,7 @@ ARG UPGRADE=false
 
 ADD ${PKGDIR} ./dist
 
-RUN if [ "${UPGRADE}" = "true" ]; then yum -y install ${INTEGRATION}; fi; \
+RUN if [ "${UPGRADE}" = "true" ]; then \
+        yum -y install ${INTEGRATION} || echo "⚠️ Previous version install failed, proceeding anyway"; \
+    fi; \
     yum -y install ./dist/${INTEGRATION}-${TAG}-1.x86_64.rpm

--- a/linux/entrypoint.sh
+++ b/linux/entrypoint.sh
@@ -29,15 +29,18 @@ function build_and_test() {
     dockertag="$INTEGRATION:$distro-$TAG$upgradesuffix"
 
     echo "ℹ️ Running installation test for $dockertag"
+    echo "::group::docker build $dockertag"
     if ! docker build -t "$dockertag" -f "$GITHUB_ACTION_PATH/$distro.dockerfile"\
       --build-arg TAG="$TAG"\
       --build-arg INTEGRATION="$INTEGRATION"\
       --build-arg UPGRADE="$1"\
       --build-arg PKGDIR="$PKGDIR"\
     .; then
+        echo "::endgroup::"
         echo "❌ Install for $dockertag failed"
         return 1
     fi
+    echo "::endgroup::"
     echo "✅ Installation for $dockertag succeeded"
 
     echo "ℹ️ Running post-installation checks for $dockertag"
@@ -65,14 +68,10 @@ function build_and_test() {
 }
 
 echo "$DISTROS" | tr " " "\n" | while read -r distro; do
-    echo "::group::Clean install on $distro"
     build_and_test false
-    echo "::endgroup::"
 
     if [[ "$UPGRADE" = "true" ]]; then
-        echo "::group::Upgrade path on $distro"
         build_and_test true
-        echo "::endgroup::"
     else
         echo "ℹ️ Skipping upgrade path on $distro"
     fi

--- a/linux/entrypoint.sh
+++ b/linux/entrypoint.sh
@@ -25,7 +25,7 @@ $POST_INSTALL_EXTRA"
 
 function build_and_test() {
     # Do an upgrade test (i.e. install integration from the repo before installing the local package) if $1 == true
-    if [[ "$1" = "true" ]]; then upgradesuffix="-upgrade"; fi
+    if [[ "$1" == "true" ]]; then upgradesuffix="-upgrade"; fi
     dockertag="$INTEGRATION:$distro-$TAG$upgradesuffix"
 
     echo "ℹ️ Running installation test for $dockertag"

--- a/linux/suse.dockerfile
+++ b/linux/suse.dockerfile
@@ -20,5 +20,7 @@ ARG UPGRADE=false
 
 ADD ${PKGDIR} ./dist
 
-RUN if [ "${UPGRADE}" = "true" ]; then zypper -n install ${INTEGRATION}; fi; \
+RUN if [ "${UPGRADE}" = "true" ]; then \
+        zypper -n install ${INTEGRATION} || echo "⚠️ Previous version install failed, proceeding anyway"; \
+    fi; \
     zypper -n install ./dist/${INTEGRATION}-${TAG}-1.x86_64.rpm

--- a/linux/ubuntu.dockerfile
+++ b/linux/ubuntu.dockerfile
@@ -28,5 +28,7 @@ ARG UPGRADE=false
 
 ADD ${PKGDIR} ./dist
 
-RUN if [ "${UPGRADE}" = "true" ]; then apt install -y ${INTEGRATION}; fi; \
+RUN if [ "${UPGRADE}" = "true" ]; then\
+        apt install -y ${INTEGRATION} || echo "⚠️ Previous version install failed, proceeding anyway"; \
+    fi; \
     apt install -y ./dist/${INTEGRATION}_${TAG}-1_amd64.deb

--- a/windows/test_msi.ps1
+++ b/windows/test_msi.ps1
@@ -13,7 +13,12 @@ if($UPGRADE -eq "true")
     $latest_msi_url = "https://download.newrelic.com/infrastructure_agent/windows/integrations/${INTEGRATION}/${latest_msi_name}"
     write-host "===> Downloading latest released version of msi from ${latest_msi_url}"
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    $r = Invoke-WebRequest "${latest_msi_url}" -OutFile "${latest_msi_name}"
+    try {
+        Invoke-WebRequest "${latest_msi_url}" -OutFile "${latest_msi_name}"
+    } catch {
+        write-host "⚠️ Couldn't fetch latest version from ${latest_msi_url}, skipping test"
+        exit 0
+    }
 
     write-host "===> Installing latest released version of msi from ${latest_msi_url}"
     $p = Start-Process msiexec.exe -Wait -PassThru -ArgumentList "/qn /L*v msi_log /i ${latest_msi_name}"


### PR DESCRIPTION
Initially, I thought about being more elegant in the Docker test, exiting with a certain exit code which would then be captured by the entrypoint and handled gracefully. I had to ditch this approach as the exit code from commands inside a Dockerfile is not propagated by the `docker build` command. Therefore the upgrade path test is carried away as a second "clean install" test. Ugly, but not much else we can do.

---

Fixes #5 