### PR TITLE
linux: add support for multiple versions of distros

### DIFF
--- a/.github/workflows/selftest-linux.yml
+++ b/.github/workflows/selftest-linux.yml
@@ -41,7 +41,7 @@ jobs:
         uses: ./linux
         with:
           tag: '.' # Match anything, just for testing
-          integration: 'nri-haproxy'
+          integration: 'nri-postgresql'
           upgrade: false
           packageLocation: 'repo'
           pkgDir: testdata/dist # PKGDir must exist or docker will fail to `COPY` things
@@ -60,7 +60,7 @@ jobs:
         uses: ./linux
         with:
           tag: '.' # Match anything, just for testing
-          integration: 'nri-haproxy'
+          integration: 'nri-postgresql'
           upgrade: false
           packageLocation: 'repo'
           pkgDir: testdata/dist # PKGDir must exist or docker will fail to `COPY` things

--- a/README.md
+++ b/README.md
@@ -46,8 +46,7 @@ The following inputs can be specified to override the default behavior
   - default: empty
 * `postInstall`: Override the post-install test script. This is run line-by-line in different containers. A non-zero exit code causes the install check to fail.
   - default: See `entrypoint.sh`
-* `distros`: Space-separated list of distros to run the test on. Supported values are "ubuntu", "suse" and "centos"
-  - default: `centos suse ubuntu`
+* `distros`: Space-separated list of distros to run the test on. See below for details.
 * `packageLocation`: Whether to test local packages (`local`) or packages from the upstream repo (`repo`). Useful for testing the staging repo.
   - *Note: Specifying both `packageLocation: repo` and `upgrade: true` is not possible and such combination will be silently ignored.*
   - default: `local`
@@ -55,6 +54,18 @@ The following inputs can be specified to override the default behavior
   - default: `false`
 * `pkgDir`: Path where archives (.deb and .rpm) reside
   - default: `./dist`
+
+##### Supported `distros`
+
+Distros to test on are supplied as docker tags, provided that a mapping between the tag and a helper script is available for it. Mapping between tags and helpers can be found here: https://github.com/newrelic/integrations-pkg-test-action/blob/master/linux/helper.sh#L8
+
+If a mapping exists for the docker image, the associated helper script will be responsible of adding to the image the corresponding repository for that particular tag.
+
+Despite not being docker tags, `action.sh` will also [accept](https://github.com/newrelic/integrations-pkg-test-action/blob/master/linux/action.sh#L27) the following values:
+* `ubuntu`
+* `suse`
+* `centos`
+* `debian`
 
 #### Running locally
 

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -3,8 +3,8 @@ FROM $BASE_IMAGE as base
 
 WORKDIR /integration
 
-ARG DISTRO
-ENV DISTRO=$DISTRO
+ARG BASE_IMAGE
+ENV BASE_IMAGE=$BASE_IMAGE
 
 # Copy helper scripts
 COPY helper*.sh rpm-repos/*.repo ./

--- a/linux/action.sh
+++ b/linux/action.sh
@@ -5,7 +5,7 @@ set -o pipefail
 
 # Populate defaults
 [[ -n $GITHUB_ACTION_PATH ]] || GITHUB_ACTION_PATH=$(pwd)
-[[ -n $DISTROS ]] || DISTROS="centos suse ubuntu"
+[[ -n $DISTROS ]] || DISTROS="ubuntu:hirsute ubuntu:focal debian:bullseye debian:buster centos:centos8 centos:centos7 suse"
 [[ -n $PKGDIR ]] || PKGDIR="./dist"
 [[ -n $PACKAGE_LOCATION ]] || PACKAGE_LOCATION="local"
 

--- a/linux/helper_centos.sh
+++ b/linux/helper_centos.sh
@@ -5,6 +5,11 @@ add_repo() {
         env="-staging"
     fi
     cp "newrelic-infra-centos${env}.repo" /etc/yum.repos.d/newrelic-infra.repo
+
+    # Get centos version from docker tag, assuming it has a `:centos[0-9]` format
+    version=${BASE_IMAGE##*:centos}
+    sed -i "s/__VERSION__/$version/" /etc/yum.repos.d/newrelic-infra.repo
+
     yum -q makecache -y --disablerepo='*' --enablerepo='newrelic-infra'
     yum update -y
 }

--- a/linux/helper_suse.sh
+++ b/linux/helper_suse.sh
@@ -8,6 +8,15 @@ add_repo() {
     fi
     cp "newrelic-infra-suse${env}.repo" /etc/zypp/repos.d/newrelic-infra.repo
 
+    # Extract version and SP from docker image
+    version=$(echo "$BASE_IMAGE" | grep -oE 'sles?[0-9]+' | grep -oE '[0-9]+')
+    sp=$(echo "$BASE_IMAGE" | grep -oE 'sp[0-9]+' | grep -oE '[0-9]+')
+    if [ -n "$sp" ]; then
+        version="${version}.${sp}"
+    fi
+
+    sed -i "s/__VERSION__/$version/" /etc/yum.repos.d/newrelic-infra.repo
+
     wget -nv -O- http://nr-downloads-main.s3-website-us-east-1.amazonaws.com/infrastructure_agent/gpg/newrelic-infra.gpg |  gpg --import
     zypper --gpg-auto-import-keys ref
     zypper -n ref -r newrelic-infra

--- a/linux/helper_ubuntu.sh
+++ b/linux/helper_ubuntu.sh
@@ -1,13 +1,20 @@
 # Adds the NR repo
 add_repo() {
-    apt update && apt -y install wget gnupg
-    if [ "$STAGING_REPO" = "true" ]; then
-        repo="http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/infrastructure_agent/linux/apt";
-    else
-        repo="http://nr-downloads-main.s3-website-us-east-1.amazonaws.com/infrastructure_agent/linux/apt";
+    # Extract :version from DISTRO tag
+    version=${BASE_IMAGE##*:}
+    if [ -z "$version" ]; then
+        printf "Cannot figure out version from BASE_IMAGE %s" "$BASE_IMAGE"
+        return 1
     fi
 
-    echo "deb [arch=amd64] $repo focal main" > /etc/apt/sources.list.d/newrelic-infra.list
+    apt update && apt -y install wget gnupg
+    if [ "$STAGING_REPO" = "true" ]; then
+        repo="http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/infrastructure_agent/linux/apt"
+    else
+        repo="http://nr-downloads-main.s3-website-us-east-1.amazonaws.com/infrastructure_agent/linux/apt"
+    fi
+
+    echo "deb [arch=amd64] $repo $version main" > /etc/apt/sources.list.d/newrelic-infra.list
     wget -nv -O- http://nr-downloads-main.s3-website-us-east-1.amazonaws.com/infrastructure_agent/gpg/newrelic-infra.gpg | apt-key add -
     apt update
 }

--- a/linux/rpm-repos/newrelic-infra-centos-staging.repo
+++ b/linux/rpm-repos/newrelic-infra-centos-staging.repo
@@ -1,6 +1,6 @@
 [newrelic-infra]
 name=New Relic Infrastructure
-baseurl=http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/infrastructure_agent/linux/yum/el/8/x86_64
+baseurl=http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/infrastructure_agent/linux/yum/el/__VERSION__/x86_64
 gpgkey=http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/infrastructure_agent/gpg/newrelic-infra.gpg
 gpgcheck=1
 repo_gpgcheck=1

--- a/linux/rpm-repos/newrelic-infra-centos.repo
+++ b/linux/rpm-repos/newrelic-infra-centos.repo
@@ -1,6 +1,6 @@
 [newrelic-infra]
 name=New Relic Infrastructure
-baseurl=http://nr-downloads-main.s3-website-us-east-1.amazonaws.com/infrastructure_agent/linux/yum/el/8/x86_64
+baseurl=http://nr-downloads-main.s3-website-us-east-1.amazonaws.com/infrastructure_agent/linux/yum/el/__VERSION__/x86_64
 gpgkey=http://nr-downloads-main.s3-website-us-east-1.amazonaws.com/infrastructure_agent/gpg/newrelic-infra.gpg
 gpgcheck=1
 repo_gpgcheck=1


### PR DESCRIPTION
This PR implements support for multiple versions of the same distro.

Mainly two things have changed w.r.t. the previous approach:

1. Distros can now be specified as docker images directly. Simplified names (`ubuntu`, `suse`, etc.) can still be used and are aliased to a default version in the script using the `qualify_distro` function.
2. `helper.sh` and `helper_$distro.sh` have been updated to expect a docker image in the `BASE_IMAGE` variable, which then can use to decide which repo should be used for that particular version.

Other minor changes:

* `DISTRO` env var has been removed as it introduced some ambiguity (is it the distro name or the docker image name?)
* RPM files include placeholders (`__VERSION__`) that are replaced in-code.