### PR TITLE
linux: remove suse 12 support

### DIFF
--- a/linux/action.sh
+++ b/linux/action.sh
@@ -5,7 +5,7 @@ set -o pipefail
 
 # Populate defaults
 [[ -n $GITHUB_ACTION_PATH ]] || GITHUB_ACTION_PATH=$(pwd)
-[[ -n $DISTROS ]] || DISTROS="ubuntu:hirsute ubuntu:focal ubuntu:bionic debian:bullseye debian:buster centos:centos8 centos:centos7 suse registry.suse.com/suse/sles12sp5:latest"
+[[ -n $DISTROS ]] || DISTROS="ubuntu:hirsute ubuntu:focal ubuntu:bionic debian:bullseye debian:buster centos:centos8 centos:centos7 suse"
 [[ -n $PKGDIR ]] || PKGDIR="./dist"
 [[ -n $PACKAGE_LOCATION ]] || PACKAGE_LOCATION="local"
 

--- a/linux/helper_suse.sh
+++ b/linux/helper_suse.sh
@@ -1,7 +1,5 @@
 # Adds the NR repo
 add_repo() {
-    zypper -n install wget gnupg
-
     env=""
     if [ "$STAGING_REPO" = "true" ]; then
         env="-staging"
@@ -10,13 +8,27 @@ add_repo() {
 
     # Extract version and SP from docker image
     version=$(echo "$BASE_IMAGE" | grep -oE 'sles?[0-9]+' | grep -oE '[0-9]+')
+    if [ -z "$version" ]; then
+        printf "Unable to parse Suse version from BASE_IMAGE tag '%s'" "$BASE_IMAGE"
+        return 1
+    fi
+
+    # Versions earlier than 15 are deprecated and their repos are down. E.g. installing wget is not possible.
+    if [ "$version" -lt 15 ]; then
+        echo "Only Suse versions 15 and higher are supported by this action"
+        return 2
+    fi
+
     sp=$(echo "$BASE_IMAGE" | grep -oE 'sp[0-9]+' | grep -oE '[0-9]+')
     if [ -n "$sp" ]; then
         version="${version}.${sp}"
     fi
 
+    printf "Detected version '%s' from docker tag" "$version"
+
     sed -i "s/__VERSION__/$version/" /etc/yum.repos.d/newrelic-infra.repo
 
+    zypper -n install wget gnupg
     wget -nv -O- http://nr-downloads-main.s3-website-us-east-1.amazonaws.com/infrastructure_agent/gpg/newrelic-infra.gpg |  gpg --import
     zypper --gpg-auto-import-keys ref
     zypper -n ref -r newrelic-infra


### PR DESCRIPTION
Suse 12 repos are no longer up, and it's not possible to install dependencies (e.g. wget) from them