### PR TITLE
chore(ubuntu): update default latest version

### DIFF
--- a/.github/workflows/selftest-linux.yml
+++ b/.github/workflows/selftest-linux.yml
@@ -55,7 +55,7 @@ jobs:
         uses: ./linux
         with:
           tag: '.' # Match anything, just for testing
-          integration: 'nri-postgresql'
+          integration: 'nri-f5'
           upgrade: false
           packageLocation: 'repo'
           pkgDir: testdata/dist # PKGDir must exist or docker will fail to `COPY` things
@@ -74,7 +74,7 @@ jobs:
         uses: ./linux
         with:
           tag: '.' # Match anything, just for testing
-          integration: 'nri-postgresql'
+          integration: 'nri-f5'
           upgrade: false
           packageLocation: 'repo'
           pkgDir: testdata/dist # PKGDir must exist or docker will fail to `COPY` things

--- a/linux/action.sh
+++ b/linux/action.sh
@@ -31,7 +31,7 @@ function qualify_distro() {
         printf '%s' "$1"
         ;;
     "ubuntu")
-        printf "ubuntu:hirsute"
+        printf "ubuntu:jammy"
         ;;
     "suse")
         printf "registry.suse.com/suse/sle15:latest"


### PR DESCRIPTION
F5 has been published, therefore we can bump the lasted version in the defaults