### PR TITLE
fix: point default suse to last supported version by NR

### DIFF
--- a/linux/action.sh
+++ b/linux/action.sh
@@ -34,7 +34,7 @@ function qualify_distro() {
         printf "ubuntu:jammy"
         ;;
     "suse")
-        printf "registry.suse.com/suse/sle15:latest"
+        printf "registry.suse.com/suse/sle15:15.3"
         ;;
     "rockylinux")
         printf "rockylinux:8"


### PR DESCRIPTION
The image `registry.suse.com/suse/sle15:latest` corresponds to 15.4 which is[ not supported yet by the Agent](http://nr-downloads-main.s3-website-us-east-1.amazonaws.com/infrastructure_agent/linux/zypp/sles/) so we don't have the packages for it. This makes the action [fail](https://github.com/newrelic/nri-couchbase/runs/6986035062?check_suite_focus=true#step:6:5127) when executing. 

This PR points the default to the last supported version which we have packages for it.