### PR TITLE
NR-340027 Add destPrefix input flag

### DIFF
--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -12,6 +12,8 @@ COPY helper*.sh rpm-repos/*.repo ./
 ARG STAGING_REPO=false
 ENV STAGING_REPO=$STAGING_REPO
 
+ARG DEST_PREFIX
+
 # Run helper prepare. This adds the NR repo and installs the agent
 RUN ./helper.sh prepare
 
@@ -41,4 +43,5 @@ RUN INTEGRATION=$INTEGRATION \
     INSTALL_REPO=$INSTALL_REPO \
     FAIL_REPO=$FAIL_REPO \
     INSTALL_LOCAL=$INSTALL_LOCAL \
+    DEST_PREFIX=$DEST_PREFIX \
     ./helper.sh install

--- a/linux/action.sh
+++ b/linux/action.sh
@@ -8,6 +8,7 @@ set -o pipefail
 [[ -n $DISTROS ]] || DISTROS="ubuntu:jammy ubuntu:focal ubuntu:bionic debian:bullseye debian:buster rockylinux:8 registry.suse.com/suse/sles12sp5:latest suse"
 [[ -n $PKGDIR ]] || PKGDIR="./dist"
 [[ -n $PACKAGE_LOCATION ]] || PACKAGE_LOCATION="local"
+[[ -n $DEST_PREFIX ]] || DEST_PREFIX="infrastructure_agent"
 
 # Strip leading v from TAG and REPO_VERSION if present
 TAG=${TAG/v/}
@@ -125,6 +126,7 @@ function build_and_test() {
         --build-arg INSTALL_LOCAL="$install_local" \
         --build-arg FAIL_REPO="$fail_repo" \
         --build-arg STAGING_REPO="$STAGING_REPO" \
+        --build-arg DEST_PREFIX="$DEST_PREFIX" \
         "$dockerdir"; then
         echo "::endgroup::"
         echo "❌ Install for $dockertag failed"

--- a/linux/action.yml
+++ b/linux/action.yml
@@ -41,6 +41,10 @@ inputs:
     description: 'Folder containing installer packages'
     required: false
     default: ""
+  destPrefix:
+    description: 'Prefix of the destination s3 path for downloading the artifacts'
+    required: false
+    default: "infrastructure_agent"
 
 runs:
   using: "composite"
@@ -58,3 +62,4 @@ runs:
         POST_INSTALL_EXTRA: ${{ inputs.postInstallExtra }}
         DISTROS: ${{ inputs.distros }}
         PKGDIR: ${{ inputs.pkgDir }}
+        DEST_PREFIX: ${{ inputs.destPrefix }}

--- a/linux/helper_rockylinux.sh
+++ b/linux/helper_rockylinux.sh
@@ -6,6 +6,18 @@ add_repo() {
     fi
     cp "newrelic-infra-rockylinux${env}.repo" /etc/yum.repos.d/newrelic-infra.repo
 
+    if [ "$STAGING_REPO" = "true" ]; then 
+        if [ "$DEST_PREFIX" != "infrastructure_agent"]; then
+            sed -i "s|baseurl=http://nr-downloads-ohai-staging\.s3-website-us-east-1\.amazonaws\.com/infrastructure_agent/linux/yum/el/__VERSION__/x86_64|baseurl=http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/${DEST_PREFIX}/linux/yum/el/__VERSION__/x86_64|" /etc/yum.repos.d/newrelic-infra.repo
+            sed -i "s|gpgkey=http://nr-downloads-ohai-staging\.s3-website-us-east-1\.amazonaws\.com/infrastructure_agent/gpg/newrelic-infra\.gpg|gpgkey=http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/${DEST_PREFIX}/gpg/newrelic-infra.gpg|" /etc/yum.repos.d/newrelic-infra.repo
+        fi
+    else
+        if [ "$DEST_PREFIX" != "infrastructure_agent"]; then
+            sed -i "s|baseurl=http://nr-downloads-main\.s3-website-us-east-1\.amazonaws\.com/infrastructure_agent/linux/yum/el/__VERSION__/x86_64|baseurl=http://nr-downloads-main.s3-website-us-east-1.amazonaws.com/${DEST_PREFIX}/linux/yum/el/__VERSION__/x86_64|" /etc/yum.repos.d/newrelic-infra.repo
+            sed -i "s|gpgkey=http://nr-downloads-main\.s3-website-us-east-1\.amazonaws\.com/infrastructure_agent/gpg/newrelic-infra.gpg|gpgkey=http://nr-downloads-main.s3-website-us-east-1.amazonaws.com/${DEST_PREFIX}/gpg/newrelic-infra.gpg|" /etc/yum.repos.d/newrelic-infra.repo
+        fi
+    fi
+
     # Get rockylinux version from docker tag, assuming it has a `:[0-9]` format
     version=${BASE_IMAGE##*:}
     sed -i "s/__VERSION__/$version/" /etc/yum.repos.d/newrelic-infra.repo

--- a/linux/helper_suse.sh
+++ b/linux/helper_suse.sh
@@ -27,11 +27,22 @@ add_repo() {
         zypper --gpg-auto-import-keys ref
     fi
     zypper -n install wget
-    wget -q "http://${domain}/infrastructure_agent/gpg/newrelic-infra.gpg" -O newrelic-infra.gpg
+    wget -q "http://${domain}/$DEST_PREFIX/gpg/newrelic-infra.gpg" -O newrelic-infra.gpg
     rpm --import newrelic-infra.gpg && rm newrelic-infra.gpg
 
     cp "newrelic-infra-suse${env}.repo" tmp.repo
     sed -e "s/__VERSION__/$VERSION_ID/g" tmp.repo > /etc/zypp/repos.d/newrelic-infra.repo
+    if [ "$STAGING_REPO" = "true" ]; then 
+        if [ "$DEST_PREFIX" != "infrastructure_agent"]; then
+            sed -i "s|baseurl=http://nr-downloads-ohai-staging\.s3-website-us-east-1\.amazonaws\.com/infrastructure_agent/linux/zypp/sles/__VERSION__/x86_64|baseurl=http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/${DEST_PREFIX}/linux/zypp/sles/__VERSION__/x86_64|" /etc/zypp/repos.d/newrelic-infra.repo
+            sed -i "s|gpgkey=http://download\.newrelic\.com/infrastructure_agent/gpg/newrelic-infra\.gpg|gpgkey=http://download.newrelic.com/${DEST_PREFIX}/gpg/newrelic-infra.gpg|" /etc/zypp/repos.d/newrelic-infra.repo
+        fi
+    else
+        if [ "$DEST_PREFIX" != "infrastructure_agent"]; then
+            sed -i "s|baseurl=http://nr-downloads-main\.s3-website-us-east-1\.amazonaws\.com/infrastructure_agent/linux/zypp/sles/__VERSION__/x86_64|baseurl=http://nr-downloads-main.s3-website-us-east-1.amazonaws.com/${DEST_PREFIX}/linux/zypp/sles/__VERSION__/x86_64|" /etc/zypp/repos.d/newrelic-infra.repo
+            sed -i "s|gpgkey=http://nr-downloads-main\.s3-website-us-east-1\.amazonaws\.com/infrastructure_agent/gpg/newrelic-infra.gpg|gpgkey=http://nr-downloads-main.s3-website-us-east-1.amazonaws.com/${DEST_PREFIX}/gpg/newrelic-infra.gpg|" /etc/zypp/repos.d/newrelic-infra.repo
+        fi
+    fi
     zypper --gpg-auto-import-keys ref
 }
 

--- a/linux/helper_ubuntu.sh
+++ b/linux/helper_ubuntu.sh
@@ -9,13 +9,13 @@ add_repo() {
 
     apt update && apt -y install wget gnupg
     if [ "$STAGING_REPO" = "true" ]; then
-        repo="http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/infrastructure_agent/linux/apt"
+        repo="http://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/$DEST_PREFIX/linux/apt"
     else
-        repo="http://nr-downloads-main.s3-website-us-east-1.amazonaws.com/infrastructure_agent/linux/apt"
+        repo="http://nr-downloads-main.s3-website-us-east-1.amazonaws.com/$DEST_PREFIX/linux/apt"
     fi
 
     echo "deb [arch=amd64] $repo $version main" > /etc/apt/sources.list.d/newrelic-infra.list
-    wget -nv -O- http://nr-downloads-main.s3-website-us-east-1.amazonaws.com/infrastructure_agent/gpg/newrelic-infra.gpg | apt-key add -
+    wget -nv -O- http://nr-downloads-main.s3-website-us-east-1.amazonaws.com/$DEST_PREFIX/gpg/newrelic-infra.gpg | apt-key add -
     apt update
 }
 
@@ -25,7 +25,7 @@ install_agent() {
     # apt install -y newrelic-infra
 
     AGENT_PACKAGE=${AGENT_PACKAGE:-newrelic-infra_systemd_1.15.2_systemd_amd64.deb}
-    wget -nv "http://nr-downloads-main.s3-website-us-east-1.amazonaws.com/infrastructure_agent/linux/apt/pool/main/n/newrelic-infra/${AGENT_PACKAGE}"
+    wget -nv "http://nr-downloads-main.s3-website-us-east-1.amazonaws.com/$DEST_PREFIX/linux/apt/pool/main/n/newrelic-infra/${AGENT_PACKAGE}"
     apt install "./${AGENT_PACKAGE}"
 }
 

--- a/windows/action.yml
+++ b/windows/action.yml
@@ -45,6 +45,10 @@ inputs:
     description: 'Path to the upstream URL of the package. Will be concatenated with pkgUpstreamName to get the full URL'
     required: false
     default: ""
+  destPrefix:
+    description: 'Prefix of the destination s3 path for downloading the artifacts'
+    required: false
+    default: "infrastructure_agent"
 
 runs:
   using: "composite"
@@ -61,6 +65,7 @@ runs:
         $Env:pkgUpstreamBaseURL="${{ inputs.pkgUpstreamBaseURL }}"
         $Env:pkgLatestName="${{ inputs.pkgLatestName }}"
         $Env:repoVersion="${{ inputs.repoVersion }}"
+        $Env:destPrefix="${{ inputs.destPrefix }}"
         
         ${{ github.action_path }}\test_msi.ps1
       shell: pwsh

--- a/windows/test_msi.ps1
+++ b/windows/test_msi.ps1
@@ -9,6 +9,7 @@ $PKG_NAME = "$env:pkgName"
 $PKG_UPSTREAM_URL_BASE = "$env:pkgUpstreamBaseURL"
 $PKG_UPSTREAM_NAME = "$env:pkgLatestName"
 $REPO_VERSION = "$env:repoVersion"
+$DEST_PREFIX = "$env:destPrefix"
 
 if ($PKG_TYPE -NotMatch "msi" -And $PKG_TYPE -NotMatch "exe") {
     echo "❌ PKG_TYPE can only be 'msi' or 'exe'"
@@ -34,7 +35,7 @@ if ($PKG_UPSTREAM_NAME -eq "")
 
 if ($PKG_UPSTREAM_URL_BASE -eq "")
 {
-    $url_base = "http://nr-downloads-main.s3-website-us-east-1.amazonaws.com/infrastructure_agent/windows"
+    $url_base = "http://nr-downloads-main.s3-website-us-east-1.amazonaws.com/${DEST_PREFIX}/windows"
 
     if ($ARCH -eq "386")
     {


### PR DESCRIPTION
Changes in this PR

- Replaced hardcoded value `infrastructure_agent` with `DEST_PREFIX`
- Updated the pkg installation test files for ubuntu and windows to use `destPrefix`

Testing 
- Created a empty [repo](https://github.com/sairaj18/my-test) and added [workflow](https://github.com/sairaj18/my-test/blob/main/.github/workflows/main.yml) to run Integrations Package Test Action.
- When I ran the workflow without destPrefix the [job](https://github.com/sairaj18/my-test/actions/runs/12112523365) was successful 
- When I ran the workflow with destPrefix as `abc` the job has [failed](https://productionresultssa6.blob.core.windows.net/actions-results/e436f968-6ccf-4896-ba1e-9ee9c72e6628/workflow-job-run-5111ec38-d27d-569c-7d72-8fdee8a99ae0/logs/job/job-logs.txt?rsct=text%2Fplain&se=2024-12-02T05%3A05%3A40Z&sig=Msz525MPcLVryzwLT8suEhyJLZe6BtpLFNVb4xlyDcU%3D&ske=2024-12-02T13%3A56%3A11Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2024-12-02T01%3A56%3A11Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2024-11-04&sp=r&spr=https&sr=b&st=2024-12-02T04%3A55%3A35Z&sv=2024-11-04#:~:text=2024%2D12%2D02T04%3A30%3A51.9869800Z%20%239%2013.80%20E%3A%20The%20repository%20%27http%3A//nr%2Ddownloads%2Dohai%2Dstaging.s3%2Dwebsite%2Dus%2Deast%2D1.amazonaws.com/abc/linux/apt%20jammy%20Release%27%20does%20not%20have%20a%20Release%20file.%0A2024%2D12%2D02T04%3A30%3A51.9871601Z%20%239%2013.81%20%E2%9D%8C%20Could%20not%20add%20NR%20repo%20to%20the%20image). 