### PR TITLE
Update action.sh removed the debian:buster

### DIFF
--- a/linux/action.sh
+++ b/linux/action.sh
@@ -5,7 +5,7 @@ set -o pipefail
 
 # Populate defaults
 [[ -n $GITHUB_ACTION_PATH ]] || GITHUB_ACTION_PATH=$(pwd)
-[[ -n $DISTROS ]] || DISTROS="ubuntu:jammy ubuntu:focal ubuntu:bionic debian:bullseye debian:buster rockylinux:8 registry.suse.com/suse/sles12sp5:latest suse"
+[[ -n $DISTROS ]] || DISTROS="ubuntu:jammy ubuntu:focal ubuntu:bionic debian:bullseye rockylinux:8 registry.suse.com/suse/sles12sp5:latest suse"
 [[ -n $PKGDIR ]] || PKGDIR="./dist"
 [[ -n $PACKAGE_LOCATION ]] || PACKAGE_LOCATION="local"
 


### PR DESCRIPTION
### Description 

We have removed Debian Buster that it no longer supported and it causing the isses for nightly build for integrations 

<img width="3406" height="1838" alt="image" src="https://github.com/user-attachments/assets/6800983a-210f-4fac-96a1-e8461a243d50" />
