### PR TITLE
Add explicit least-privilege permissions to workflows

### DIFF
--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -8,6 +8,10 @@ name: Repolinter Action
 # filtered in the "Test Default Branch" step.
 on: [push, workflow_dispatch]
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   repolint:
     name: Run Repolinter

--- a/.github/workflows/selftest-linux.yml
+++ b/.github/workflows/selftest-linux.yml
@@ -7,6 +7,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 # ATTENTION
 # This is a self-test pipeline and it is *NOT* intended to be used as a base/quickstart on how to
 # use the action. Please refer to the examples in the README.md file for that

--- a/.github/workflows/selftest-windows.yml
+++ b/.github/workflows/selftest-windows.yml
@@ -7,6 +7,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   msi-package:
     runs-on: windows-2019


### PR DESCRIPTION
CodeQL (actions/missing-workflow-permissions) flagged all 9 jobs across our 3 workflow files for not declaring GITHUB_TOKEN permissions, which means they inherited the repo's default "write" token scope even though none of them need it.

- repolinter.yml: contents: read, issues: write (repolinter-action creates/updates a GitHub issue when output_type is "issue")
- selftest-linux.yml / selftest-windows.yml: contents: read only, since these jobs just checkout and run local composite actions

Resolves NR-560270 (code-scanning alerts #1-#9).